### PR TITLE
write to shapefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ arguments are those accepted by `GeoJSON.read`, `GeoJSON.write`, `Shapefile.Tabl
 `Shapefile.write` and `ArchGDAL.read`. See below some examples:
 
 ```julia
-# Read `.geojson` geometries with Float64 precision.
+# read `.geojson` geometries with Float64 precision
 table = GeoTables.load("file.geojson", numbertype = Float64)
 
-# Force writing on existing `.shp` file.
+# force writing on existing `.shp` file
 GeoTables.save("file.shp", table, force = true)
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ GeoTables.save("file.geojson", table)
 
 Additional keyword arguments can be passed to `load` and `save` functions. Valid
 arguments are those accepted by `GeoJSON.read`, `GeoJSON.write`, `Shapefile.Table`,
-`Shapefile.write` and `ArchGDAL.read`. See below some examples.
+`Shapefile.write` and `ArchGDAL.read`. See below some examples:
 
 ```julia
-# Read GeoJSON geometries as Float64.
+# Read `.geojson` geometries with Float64 precision.
 table = GeoTables.load("file.geojson", numbertype = Float64)
 
-# Force Shapefile to write on existing file.
+# Force writing on existing `.shp` file.
 GeoTables.save("file.shp", table, force = true)
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ table = GeoTables.load("file.shp")
 GeoTables.save("file.geojson", table)
 ```
 
+Additional keyword arguments can be passed to `load` and `save` functions. Valid
+arguments are those accepted by `GeoJSON.read`, `GeoJSON.write`, `Shapefile.Table`,
+`Shapefile.write` and `ArchGDAL.read`. See below some examples.
+
+```julia
+# Read GeoJSON geometries as Float64.
+table = GeoTables.load("file.geojson", numbertype = Float64)
+
+# Force Shapefile to write on existing file.
+GeoTables.save("file.shp", table, force = true)
+```
+
 ### Loading data from GADM
 
 The `gadm` function (down)loads data from the GADM dataset:

--- a/src/GeoTables.jl
+++ b/src/GeoTables.jl
@@ -57,7 +57,7 @@ appropriate format based on the file extension.
 function save(fname, geotable; kwargs...)
   if endswith(fname, ".shp")
     geoms = domain(geotable)
-    if !isa(geoms[1], Multi) & !isa(geoms[1], Point)
+    if !(geoms[1] isa Multi) && !(geoms[1] isa Point)
       newgeoms = GeometrySet([Multi([geom]) for geom in geoms])
       geotable = meshdata(newgeoms, etable = values(geotable))
     end

--- a/src/GeoTables.jl
+++ b/src/GeoTables.jl
@@ -56,11 +56,10 @@ appropriate format based on the file extension.
 """
 function save(fname, geotable; kwargs...)
   if endswith(fname, ".shp")
-    geotable = MeshData(geotable)
     geoms = domain(geotable)
     if !isa(geoms[1], Multi) & !isa(geoms[1], Point)
-      geoms = GeometrySet(map(x -> Multi([x]), geoms))
-      geotable = meshdata(geoms, etable = values(geotable))
+      newgeoms = GeometrySet([Multi([geom]) for geom in geoms])
+      geotable = meshdata(newgeoms, etable = values(geotable))
     end
     SHP.write(fname, geotable; kwargs...)
   elseif endswith(fname, ".geojson")

--- a/src/GeoTables.jl
+++ b/src/GeoTables.jl
@@ -19,11 +19,14 @@ include("conversion.jl")
 include("geotable.jl")
 
 """
-    load(fname, layer=0)
+    load(fname, layer=0, kwargs...)
 
 Load geospatial table from file `fname` and convert the
 `geometry` column to Meshes.jl geometries. Optionally,
-specify the layer of geometries to read within the file.
+specify the layer of geometries to read within the file and
+keyword arguments accepted by `Shapefile.Table`, `GeoJSON.read`
+and `ArchGDAL.read`. For example, use `numbertype = Float64` to
+read `.geojson` geometries with Float64 precision.
 
 ## Supported formats
 
@@ -45,13 +48,17 @@ function load(fname; layer=0, kwargs...)
 end
 
 """
-    save(fname, geotable)
+    save(fname, geotable; kwargs...)
 
 Save geospatial table to file `fname` using the
 appropriate format based on the file extension.
+Optionally, specify keyword arguments accepted by
+`Shapefile.write` and `GeoJSON.write`. For example, use
+`force = true` to force writing on existing `.shp` file.
 
 ## Supported formats
 
+- `*.shp` via Shapefile.jl
 - `*.geojson` via GeoJSON.jl
 """
 function save(fname, geotable; kwargs...)

--- a/src/GeoTables.jl
+++ b/src/GeoTables.jl
@@ -63,11 +63,6 @@ Optionally, specify keyword arguments accepted by
 """
 function save(fname, geotable; kwargs...)
   if endswith(fname, ".shp")
-    geoms = domain(geotable)
-    if !(geoms[1] isa Multi) && !(geoms[1] isa Point)
-      newgeoms = GeometrySet([Multi([geom]) for geom in geoms])
-      geotable = meshdata(newgeoms, etable = values(geotable))
-    end
     SHP.write(fname, geotable; kwargs...)
   elseif endswith(fname, ".geojson")
     GJS.write(fname, geotable; kwargs...)

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -20,15 +20,19 @@ GI.ncoord(::GI.PointTrait, p::Point) = embeddim(p)
 GI.getcoord(::GI.PointTrait, p::Point) = coordinates(p)
 GI.getcoord(::GI.PointTrait, p::Point, i) = coordinates(p)[i]
 
-GI.ngeom(::Any, s::Segment) = nvertices(s)
-GI.getgeom(::Any, s::Segment, i) = vertices(s)[i]
+GI.ncoord(::GI.LineTrait, s::Segment) = embeddim(s)
+GI.ngeom(::GI.LineTrait, s::Segment) = nvertices(s)
+GI.getgeom(::GI.LineTrait, s::Segment, i) = vertices(s)[i]
 
-GI.ngeom(::Any, c::Chain) = nvertices(c)
-GI.getgeom(::Any, c::Chain, i) = vertices(c)[i]
+GI.ncoord(::GI.LineStringTrait, c::Chain) = embeddim(c)
+GI.ngeom(::GI.LineStringTrait, c::Chain) = nvertices(c)
+GI.getgeom(::GI.LineStringTrait, c::Chain, i) = vertices(c)[i]
 
-GI.ngeom(::Any, p::Polygon) = length(chains(p))
-GI.getgeom(::Any, p::Polygon, i) = chains(p)[i]
+GI.ncoord(::GI.PolygonTrait, p::Polygon) = embeddim(p)
+GI.ngeom(::GI.PolygonTrait, p::Polygon) = length(chains(p))
+GI.getgeom(::GI.PolygonTrait, p::Polygon, i) = chains(p)[i]
 
+GI.ncoord(::Any, m::Multi) = embeddim(m)
 GI.ngeom(::Any, m::Multi) = length(collect(m))
 GI.getgeom(::Any, m::Multi, i) = collect(m)[i]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -201,63 +201,61 @@ datadir = joinpath(@__DIR__,"data")
   end
 
   @testset "save" begin
-    writedir = joinpath(tempdir(), "geotables")
-    mkdir(writedir)
 
     @testset "points" begin
       table = GeoTables.load(joinpath(datadir, "points.geojson"), )
-      GeoTables.save(joinpath(writedir, "tpoints.geojson"), table)
-      GeoTables.save(joinpath(writedir, "tpoints.shp"), table, force = true)
+      GeoTables.save(joinpath(datadir, "tpoints.geojson"), table)
+      GeoTables.save(joinpath(datadir, "tpoints.shp"), table, force = true)
 
       table = GeoTables.load(joinpath(datadir, "points.gpkg"))
-      GeoTables.save(joinpath(writedir, "tpoints.geojson"), table)
-      GeoTables.save(joinpath(writedir, "tpoints.shp"), table, force = true)
+      GeoTables.save(joinpath(datadir, "tpoints.geojson"), table)
+      GeoTables.save(joinpath(datadir, "tpoints.shp"), table, force = true)
 
       table = GeoTables.load(joinpath(datadir, "points.shp"))
-      GeoTables.save(joinpath(writedir, "tpoints.geojson"), table)
-      GeoTables.save(joinpath(writedir, "tpoints.shp"), table, force = true)
+      GeoTables.save(joinpath(datadir, "tpoints.geojson"), table)
+      GeoTables.save(joinpath(datadir, "tpoints.shp"), table, force = true)
     end
 
     @testset "lines" begin
       table = GeoTables.load(joinpath(datadir, "lines.geojson"))
-      GeoTables.save(joinpath(writedir, "tlines.geojson"), table)
-      # GeoTables.save(joinpath(writedir, "tlines.shp"), table, force = true)
+      GeoTables.save(joinpath(datadir, "tlines.geojson"), table)
+      # GeoTables.save(joinpath(datadir, "tlines.shp"), table, force = true)
 
       table = GeoTables.load(joinpath(datadir, "lines.gpkg"))
-      GeoTables.save(joinpath(writedir, "tlines.geojson"), table)
-      # GeoTables.save(joinpath(writedir, "tlines.shp"), table, force = true)
+      GeoTables.save(joinpath(datadir, "tlines.geojson"), table)
+      # GeoTables.save(joinpath(datadir, "tlines.shp"), table, force = true)
 
       table = GeoTables.load(joinpath(datadir, "lines.shp"))
-      GeoTables.save(joinpath(writedir, "tlines.geojson"), table)
-      GeoTables.save(joinpath(writedir, "tlines.shp"), table, force = true)
+      GeoTables.save(joinpath(datadir, "tlines.geojson"), table)
+      GeoTables.save(joinpath(datadir, "tlines.shp"), table, force = true)
     end
 
     @testset "polygons" begin
       table = GeoTables.load(joinpath(datadir, "polygons.geojson"))
-      GeoTables.save(joinpath(writedir, "tpolygons.geojson"), table)
-      # GeoTables.save(joinpath(writedir, "tpolygons.shp"), table, force = true)
+      GeoTables.save(joinpath(datadir, "tpolygons.geojson"), table)
+      # GeoTables.save(joinpath(datadir, "tpolygons.shp"), table, force = true)
 
       table = GeoTables.load(joinpath(datadir, "polygons.gpkg"))
-      GeoTables.save(joinpath(writedir, "tpolygons.geojson"), table)
-      # GeoTables.save(joinpath(writedir, "tpolygons.shp"), table, force = true)
+      GeoTables.save(joinpath(datadir, "tpolygons.geojson"), table)
+      # GeoTables.save(joinpath(datadir, "tpolygons.shp"), table, force = true)
 
       table = GeoTables.load(joinpath(datadir, "polygons.shp"))
-      GeoTables.save(joinpath(writedir, "tpolygons.geojson"), table)
-      GeoTables.save(joinpath(writedir, "tpolygons.shp"), table, force = true)
+      GeoTables.save(joinpath(datadir, "tpolygons.geojson"), table)
+      GeoTables.save(joinpath(datadir, "tpolygons.shp"), table, force = true)
     end
 
     @testset "multipolygons" begin
       table = GeoTables.load(joinpath(datadir,"path.shp"))
-      GeoTables.save(joinpath(writedir, "tpath.geojson"), table)
-      GeoTables.save(joinpath(writedir, "tpath.shp"), table, force = true)
+      GeoTables.save(joinpath(datadir, "tpath.geojson"), table)
+      GeoTables.save(joinpath(datadir, "tpath.shp"), table, force = true)
 
       table = GeoTables.load(joinpath(datadir,"zone.shp"))
-      GeoTables.save(joinpath(writedir, "tzone.geojson"), table)
-      GeoTables.save(joinpath(writedir, "tzone.shp"), table, force = true)
+      GeoTables.save(joinpath(datadir, "tzone.geojson"), table)
+      GeoTables.save(joinpath(datadir, "tzone.shp"), table, force = true)
 
       table = GeoTables.load(joinpath(datadir,"ne_110m_land.shp"))
-      GeoTables.save(joinpath(writedir, "tne_110m_land.geojson"), table)
-      GeoTables.save(joinpath(writedir, "tne_110m_land.shp"), table, force = true)
+      GeoTables.save(joinpath(datadir, "tne_110m_land.geojson"), table)
+      GeoTables.save(joinpath(datadir, "tne_110m_land.shp"), table, force = true)
     end
   end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -201,10 +201,64 @@ datadir = joinpath(@__DIR__,"data")
   end
 
   @testset "save" begin
-    table = GeoTables.load(joinpath(datadir,"path.shp"))
-    GeoTables.save(joinpath(datadir,"path.geojson"), table)
-    table = GeoTables.load(joinpath(datadir,"zone.shp"))
-    GeoTables.save(joinpath(datadir,"path.geojson"), table)
+    writedir = joinpath(tempdir(), "geotables")
+    mkdir(writedir)
+
+    @testset "points" begin
+      table = GeoTables.load(joinpath(datadir, "points.geojson"), )
+      GeoTables.save(joinpath(writedir, "tpoints.geojson"), table)
+      GeoTables.save(joinpath(writedir, "tpoints.shp"), table, force = true)
+
+      table = GeoTables.load(joinpath(datadir, "points.gpkg"))
+      GeoTables.save(joinpath(writedir, "tpoints.geojson"), table)
+      GeoTables.save(joinpath(writedir, "tpoints.shp"), table, force = true)
+
+      table = GeoTables.load(joinpath(datadir, "points.shp"))
+      GeoTables.save(joinpath(writedir, "tpoints.geojson"), table)
+      GeoTables.save(joinpath(writedir, "tpoints.shp"), table, force = true)
+    end
+
+    @testset "lines" begin
+      table = GeoTables.load(joinpath(datadir, "lines.geojson"))
+      GeoTables.save(joinpath(writedir, "tlines.geojson"), table)
+      # GeoTables.save(joinpath(writedir, "tlines.shp"), table, force = true)
+
+      table = GeoTables.load(joinpath(datadir, "lines.gpkg"))
+      GeoTables.save(joinpath(writedir, "tlines.geojson"), table)
+      # GeoTables.save(joinpath(writedir, "tlines.shp"), table, force = true)
+
+      table = GeoTables.load(joinpath(datadir, "lines.shp"))
+      GeoTables.save(joinpath(writedir, "tlines.geojson"), table)
+      GeoTables.save(joinpath(writedir, "tlines.shp"), table, force = true)
+    end
+
+    @testset "polygons" begin
+      table = GeoTables.load(joinpath(datadir, "polygons.geojson"))
+      GeoTables.save(joinpath(writedir, "tpolygons.geojson"), table)
+      # GeoTables.save(joinpath(writedir, "tpolygons.shp"), table, force = true)
+
+      table = GeoTables.load(joinpath(datadir, "polygons.gpkg"))
+      GeoTables.save(joinpath(writedir, "tpolygons.geojson"), table)
+      # GeoTables.save(joinpath(writedir, "tpolygons.shp"), table, force = true)
+
+      table = GeoTables.load(joinpath(datadir, "polygons.shp"))
+      GeoTables.save(joinpath(writedir, "tpolygons.geojson"), table)
+      GeoTables.save(joinpath(writedir, "tpolygons.shp"), table, force = true)
+    end
+
+    @testset "multipolygons" begin
+      table = GeoTables.load(joinpath(datadir,"path.shp"))
+      GeoTables.save(joinpath(writedir, "tpath.geojson"), table)
+      GeoTables.save(joinpath(writedir, "tpath.shp"), table, force = true)
+
+      table = GeoTables.load(joinpath(datadir,"zone.shp"))
+      GeoTables.save(joinpath(writedir, "tzone.geojson"), table)
+      GeoTables.save(joinpath(writedir, "tzone.shp"), table, force = true)
+
+      table = GeoTables.load(joinpath(datadir,"ne_110m_land.shp"))
+      GeoTables.save(joinpath(writedir, "tne_110m_land.geojson"), table)
+      GeoTables.save(joinpath(writedir, "tne_110m_land.shp"), table, force = true)
+    end
   end
 
   @testset "gadm" begin


### PR DESCRIPTION
PR to be able to export to shapefile using `Shapefile.jl` and improve geointerface functionality. Whem geometries are `Multi`, exporting to `.shp` is quite easy with `SHP.write(fname, geotable)`, otherwise we need to convert to `Multi` and then write.