### PR TITLE
fix polygon representation when writing

### DIFF
--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -25,7 +25,7 @@ GI.ngeom(::GI.LineTrait, s::Segment) = nvertices(s)
 GI.getgeom(::GI.LineTrait, s::Segment, i) = vertices(s)[i]
 
 GI.ncoord(::GI.LineStringTrait, c::Chain) = embeddim(c)
-GI.ngeom(::GI.LineStringTrait, c::Chain) = nvertices(c)
+GI.ngeom(::GI.LineStringTrait, c::Chain) = Meshes.npoints(c)
 GI.getgeom(::GI.LineStringTrait, c::Chain, i) = vertices(c)[i]
 
 GI.ncoord(::GI.PolygonTrait, p::Polygon) = embeddim(p)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 GeoJSON = "61d90e0f-e114-555e-ac52-39dfb47a3ef9"
 Meshes = "eacbb407-ea5a-433e-ab97-5258b1ca43fa"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Tables
 using Meshes
 using Test, Random
 using Dates
+import GeoInterface as GI
 import Shapefile as SHP
 import ArchGDAL as AG
 import GeoJSON as GJS
@@ -16,6 +17,15 @@ datadir = joinpath(@__DIR__,"data")
   @testset "convert" begin
     points = Point2[(0,0),(0.5,2),(2.2,2.2)]
     outer = Point2[(0,0),(0.5,2),(2.2,2.2),(0,0)]
+
+    # GI functions
+    @test GI.ngeom(Segment(points[1:2])) == 2
+    @test GI.ngeom(Chain(points)) == 3
+    @test GI.ngeom(Chain(outer)) == 4
+    @test GI.ngeom(PolyArea(outer)) == 1
+    @test GI.ngeom(Multi(points)) == 3
+    @test GI.ngeom(Multi([Chain(outer), Chain(outer)])) == 2
+    @test GI.ngeom(Multi([PolyArea(outer), PolyArea(outer)])) == 2
 
     # Shapefile.jl
     ps = [SHP.Point(0,0), SHP.Point(0.5,2), SHP.Point(2.2,2.2)]


### PR DESCRIPTION
We were computing incorrectly the number of points of a closed chain (used for polygons). Conversion from `PolyArea` to other geometry packages were creating invalid polygons, the same was happening with writing (we were writing invalid polygons).