### PR TITLE
add shapefile tests and refactor tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,8 @@ import GeoJSON as GJS
 isCI = "CI" ∈ keys(ENV)
 islinux = Sys.islinux()
 datadir = joinpath(@__DIR__,"data")
+writedir = joinpath(tempdir(), "geotables")
+mkpath(writedir)
 
 @testset "GeoTables.jl" begin
   @testset "convert" begin
@@ -216,72 +218,52 @@ datadir = joinpath(@__DIR__,"data")
     @testset "points" begin
       for ft in filetypes
         table = GeoTables.load(joinpath(datadir, "points.$ft"))
-        GeoTables.save(joinpath(datadir, "tpoints.geojson"), table)
-        newtable = GeoTables.load(joinpath(datadir, "tpoints.geojson"))
-        GeoTables.save(joinpath(datadir, "tpoints.shp"), table, force = true)
-        newtable = GeoTables.load(joinpath(datadir, "tpoints.shp"))
+        GeoTables.save(joinpath(writedir, "tpoints.geojson"), table)
+        newtable = GeoTables.load(joinpath(writedir, "tpoints.geojson"))
+        GeoTables.save(joinpath(writedir, "tpoints.shp"), table, force = true)
+        newtable = GeoTables.load(joinpath(writedir, "tpoints.shp"))
       end
-
-      rm(joinpath(datadir, "tpoints.geojson"))
-      rm(joinpath(datadir, "tpoints.shp"))
-      rm(joinpath(datadir, "tpoints.shx"))
-      rm(joinpath(datadir, "tpoints.dbf"))
     end
 
     @testset "lines" begin
       table = GeoTables.load(joinpath(datadir, "lines.geojson"), numbertype = Float64)
-      GeoTables.save(joinpath(datadir, "tlines.geojson"), table)
-      newtable = GeoTables.load(joinpath(datadir, "tlines.geojson"))
-      GeoTables.save(joinpath(datadir, "tlines.shp"), table, force = true)
-      newtable = GeoTables.load(joinpath(datadir, "tlines.shp"))
+      GeoTables.save(joinpath(writedir, "tlines.geojson"), table)
+      newtable = GeoTables.load(joinpath(writedir, "tlines.geojson"))
+      GeoTables.save(joinpath(writedir, "tlines.shp"), table, force = true)
+      newtable = GeoTables.load(joinpath(writedir, "tlines.shp"))
 
       for ft in ["gpkg", "shp"]
         table = GeoTables.load(joinpath(datadir, "lines.$ft"))
-        GeoTables.save(joinpath(datadir, "tlines.geojson"), table)
-        newtable = GeoTables.load(joinpath(datadir, "tlines.geojson"))
-        GeoTables.save(joinpath(datadir, "tlines.shp"), table, force = true)
-        newtable = GeoTables.load(joinpath(datadir, "tlines.shp"))
+        GeoTables.save(joinpath(writedir, "tlines.geojson"), table)
+        newtable = GeoTables.load(joinpath(writedir, "tlines.geojson"))
+        GeoTables.save(joinpath(writedir, "tlines.shp"), table, force = true)
+        newtable = GeoTables.load(joinpath(writedir, "tlines.shp"))
       end
-
-      rm(joinpath(datadir, "tlines.geojson"))
-      rm(joinpath(datadir, "tlines.shp"))
-      rm(joinpath(datadir, "tlines.shx"))
-      rm(joinpath(datadir, "tlines.dbf"))
     end
 
     @testset "polygons" begin
       table = GeoTables.load(joinpath(datadir, "polygons.geojson"), numbertype = Float64)
-      GeoTables.save(joinpath(datadir, "tpolygons.geojson"), table)
-      newtable = GeoTables.load(joinpath(datadir, "tpolygons.geojson"))
-      GeoTables.save(joinpath(datadir, "tpolygons.shp"), table, force = true)
-      newtable = GeoTables.load(joinpath(datadir, "tpolygons.shp"))
+      GeoTables.save(joinpath(writedir, "tpolygons.geojson"), table)
+      newtable = GeoTables.load(joinpath(writedir, "tpolygons.geojson"))
+      GeoTables.save(joinpath(writedir, "tpolygons.shp"), table, force = true)
+      newtable = GeoTables.load(joinpath(writedir, "tpolygons.shp"))
 
       for ft in ["gpkg", "shp"]
         table = GeoTables.load(joinpath(datadir, "polygons.$ft"))
-        GeoTables.save(joinpath(datadir, "tpolygons.geojson"), table)
-        newtable = GeoTables.load(joinpath(datadir, "tpolygons.geojson"))
-        GeoTables.save(joinpath(datadir, "tpolygons.shp"), table, force = true)
-        newtable = GeoTables.load(joinpath(datadir, "tpolygons.shp"))
+        GeoTables.save(joinpath(writedir, "tpolygons.geojson"), table)
+        newtable = GeoTables.load(joinpath(writedir, "tpolygons.geojson"))
+        GeoTables.save(joinpath(writedir, "tpolygons.shp"), table, force = true)
+        newtable = GeoTables.load(joinpath(writedir, "tpolygons.shp"))
       end
-
-      rm(joinpath(datadir, "tpolygons.geojson"))
-      rm(joinpath(datadir, "tpolygons.shp"))
-      rm(joinpath(datadir, "tpolygons.shx"))
-      rm(joinpath(datadir, "tpolygons.dbf"))
     end
 
     @testset "multipolygons" begin
       for file in ["path", "zone", "ne_110m_land"]
         table = GeoTables.load(joinpath(datadir,"$file.shp"))
-        GeoTables.save(joinpath(datadir, "t$file.geojson"), table)
-        newtable = GeoTables.load(joinpath(datadir, "t$file.geojson"))
-        GeoTables.save(joinpath(datadir, "t$file.shp"), table, force = true)
-        newtable = GeoTables.load(joinpath(datadir, "t$file.shp"))
-
-        rm(joinpath(datadir, "t$file.geojson"))
-        rm(joinpath(datadir, "t$file.shp"))
-        rm(joinpath(datadir, "t$file.shx"))
-        rm(joinpath(datadir, "t$file.dbf"))
+        GeoTables.save(joinpath(writedir, "t$file.geojson"), table)
+        newtable = GeoTables.load(joinpath(writedir, "t$file.geojson"))
+        GeoTables.save(joinpath(writedir, "t$file.shp"), table, force = true)
+        newtable = GeoTables.load(joinpath(writedir, "t$file.shp"))
       end
     end
   end
@@ -297,3 +279,5 @@ datadir = joinpath(@__DIR__,"data")
     @test nitems(table) == 36
   end
 end
+
+rm(writedir, recursive = true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,8 +12,7 @@ import GeoJSON as GJS
 isCI = "CI" ∈ keys(ENV)
 islinux = Sys.islinux()
 datadir = joinpath(@__DIR__,"data")
-writedir = joinpath(tempdir(), "geotables")
-mkpath(writedir)
+writedir = mktempdir()
 
 @testset "GeoTables.jl" begin
   @testset "convert" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,13 +33,13 @@ datadir = joinpath(@__DIR__,"data")
     box = SHP.Rect(0.0, 0.0, 2.2, 2.2)
     point = SHP.Point(1.0,1.0)
     chain = SHP.LineString{SHP.Point}(view(ps, 1:3))
-    poly = SHP.SubPolygon([SHP.LinearRing{SHP.Point}(view(ps, 1:3))])
+    poly = SHP.SubPolygon([SHP.LinearRing{SHP.Point}(view(exterior, 1:4))])
     multipoint = SHP.MultiPoint(box, ps)
     multichain = SHP.Polyline(box, [0,3], repeat(ps, 2))
     multipoly = SHP.Polygon(box, [0,4], repeat(exterior, 2))
     @test GeoTables.geom2meshes(point) == Point(1.0, 1.0)
-    # @test GeoTables.geom2meshes(chain) == Chain(points)
-    # @test GeoTables.geom2meshes(poly) == PolyArea(outer)
+    @test GeoTables.geom2meshes(chain) == Chain(points)
+    @test GeoTables.geom2meshes(poly) == PolyArea(outer)
     @test GeoTables.geom2meshes(multipoint) == Multi(points)
     @test GeoTables.geom2meshes(multichain) == Multi([Chain(points), Chain(points)])
     @test GeoTables.geom2meshes(multipoly) == Multi([PolyArea(outer), PolyArea(outer)])
@@ -211,18 +211,16 @@ datadir = joinpath(@__DIR__,"data")
   end
 
   @testset "save" begin
+    filetypes = ["geojson", "gpkg", "shp"]
+
     @testset "points" begin
-      table = GeoTables.load(joinpath(datadir, "points.geojson"), )
-      GeoTables.save(joinpath(datadir, "tpoints.geojson"), table)
-      GeoTables.save(joinpath(datadir, "tpoints.shp"), table, force = true)
-
-      table = GeoTables.load(joinpath(datadir, "points.gpkg"))
-      GeoTables.save(joinpath(datadir, "tpoints.geojson"), table)
-      GeoTables.save(joinpath(datadir, "tpoints.shp"), table, force = true)
-
-      table = GeoTables.load(joinpath(datadir, "points.shp"))
-      GeoTables.save(joinpath(datadir, "tpoints.geojson"), table)
-      GeoTables.save(joinpath(datadir, "tpoints.shp"), table, force = true)
+      for ft in filetypes
+        table = GeoTables.load(joinpath(datadir, "points.$ft"))
+        GeoTables.save(joinpath(datadir, "tpoints.geojson"), table)
+        newtable = GeoTables.load(joinpath(datadir, "tpoints.geojson"))
+        GeoTables.save(joinpath(datadir, "tpoints.shp"), table, force = true)
+        newtable = GeoTables.load(joinpath(datadir, "tpoints.shp"))
+      end
 
       rm(joinpath(datadir, "tpoints.geojson"))
       rm(joinpath(datadir, "tpoints.shp"))
@@ -231,17 +229,19 @@ datadir = joinpath(@__DIR__,"data")
     end
 
     @testset "lines" begin
-      table = GeoTables.load(joinpath(datadir, "lines.geojson"))
+      table = GeoTables.load(joinpath(datadir, "lines.geojson"), numbertype = Float64)
       GeoTables.save(joinpath(datadir, "tlines.geojson"), table)
-      # GeoTables.save(joinpath(datadir, "tlines.shp"), table, force = true)
-
-      table = GeoTables.load(joinpath(datadir, "lines.gpkg"))
-      GeoTables.save(joinpath(datadir, "tlines.geojson"), table)
-      # GeoTables.save(joinpath(datadir, "tlines.shp"), table, force = true)
-
-      table = GeoTables.load(joinpath(datadir, "lines.shp"))
-      GeoTables.save(joinpath(datadir, "tlines.geojson"), table)
+      newtable = GeoTables.load(joinpath(datadir, "tlines.geojson"))
       GeoTables.save(joinpath(datadir, "tlines.shp"), table, force = true)
+      newtable = GeoTables.load(joinpath(datadir, "tlines.shp"))
+
+      for ft in ["gpkg", "shp"]
+        table = GeoTables.load(joinpath(datadir, "lines.$ft"))
+        GeoTables.save(joinpath(datadir, "tlines.geojson"), table)
+        newtable = GeoTables.load(joinpath(datadir, "tlines.geojson"))
+        GeoTables.save(joinpath(datadir, "tlines.shp"), table, force = true)
+        newtable = GeoTables.load(joinpath(datadir, "tlines.shp"))
+      end
 
       rm(joinpath(datadir, "tlines.geojson"))
       rm(joinpath(datadir, "tlines.shp"))
@@ -250,17 +250,19 @@ datadir = joinpath(@__DIR__,"data")
     end
 
     @testset "polygons" begin
-      table = GeoTables.load(joinpath(datadir, "polygons.geojson"))
+      table = GeoTables.load(joinpath(datadir, "polygons.geojson"), numbertype = Float64)
       GeoTables.save(joinpath(datadir, "tpolygons.geojson"), table)
-      # GeoTables.save(joinpath(datadir, "tpolygons.shp"), table, force = true)
-
-      table = GeoTables.load(joinpath(datadir, "polygons.gpkg"))
-      GeoTables.save(joinpath(datadir, "tpolygons.geojson"), table)
-      # GeoTables.save(joinpath(datadir, "tpolygons.shp"), table, force = true)
-
-      table = GeoTables.load(joinpath(datadir, "polygons.shp"))
-      GeoTables.save(joinpath(datadir, "tpolygons.geojson"), table)
+      newtable = GeoTables.load(joinpath(datadir, "tpolygons.geojson"))
       GeoTables.save(joinpath(datadir, "tpolygons.shp"), table, force = true)
+      newtable = GeoTables.load(joinpath(datadir, "tpolygons.shp"))
+
+      for ft in ["gpkg", "shp"]
+        table = GeoTables.load(joinpath(datadir, "polygons.$ft"))
+        GeoTables.save(joinpath(datadir, "tpolygons.geojson"), table)
+        newtable = GeoTables.load(joinpath(datadir, "tpolygons.geojson"))
+        GeoTables.save(joinpath(datadir, "tpolygons.shp"), table, force = true)
+        newtable = GeoTables.load(joinpath(datadir, "tpolygons.shp"))
+      end
 
       rm(joinpath(datadir, "tpolygons.geojson"))
       rm(joinpath(datadir, "tpolygons.shp"))
@@ -269,32 +271,18 @@ datadir = joinpath(@__DIR__,"data")
     end
 
     @testset "multipolygons" begin
-      table = GeoTables.load(joinpath(datadir,"path.shp"))
-      GeoTables.save(joinpath(datadir, "tpath.geojson"), table)
-      GeoTables.save(joinpath(datadir, "tpath.shp"), table, force = true)
+      for file in ["path", "zone", "ne_110m_land"]
+        table = GeoTables.load(joinpath(datadir,"$file.shp"))
+        GeoTables.save(joinpath(datadir, "t$file.geojson"), table)
+        newtable = GeoTables.load(joinpath(datadir, "t$file.geojson"))
+        GeoTables.save(joinpath(datadir, "t$file.shp"), table, force = true)
+        newtable = GeoTables.load(joinpath(datadir, "t$file.shp"))
 
-      rm(joinpath(datadir, "tpath.geojson"))
-      rm(joinpath(datadir, "tpath.shp"))
-      rm(joinpath(datadir, "tpath.shx"))
-      rm(joinpath(datadir, "tpath.dbf"))
-
-      table = GeoTables.load(joinpath(datadir,"zone.shp"))
-      GeoTables.save(joinpath(datadir, "tzone.geojson"), table)
-      GeoTables.save(joinpath(datadir, "tzone.shp"), table, force = true)
-
-      rm(joinpath(datadir, "tzone.geojson"))
-      rm(joinpath(datadir, "tzone.shp"))
-      rm(joinpath(datadir, "tzone.shx"))
-      rm(joinpath(datadir, "tzone.dbf"))
-
-      table = GeoTables.load(joinpath(datadir,"ne_110m_land.shp"))
-      GeoTables.save(joinpath(datadir, "tne_110m_land.geojson"), table)
-      GeoTables.save(joinpath(datadir, "tne_110m_land.shp"), table, force = true)
-
-      rm(joinpath(datadir, "tne_110m_land.geojson"))
-      rm(joinpath(datadir, "tne_110m_land.shp"))
-      rm(joinpath(datadir, "tne_110m_land.shx"))
-      rm(joinpath(datadir, "tne_110m_land.dbf"))
+        rm(joinpath(datadir, "t$file.geojson"))
+        rm(joinpath(datadir, "t$file.shp"))
+        rm(joinpath(datadir, "t$file.shx"))
+        rm(joinpath(datadir, "t$file.dbf"))
+      end
     end
   end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ import GeoJSON as GJS
 isCI = "CI" ∈ keys(ENV)
 islinux = Sys.islinux()
 datadir = joinpath(@__DIR__,"data")
-writedir = mktempdir()
+savedir = mktempdir()
 
 @testset "GeoTables.jl" begin
   @testset "convert" begin
@@ -217,52 +217,52 @@ writedir = mktempdir()
     @testset "points" begin
       for ft in filetypes
         table = GeoTables.load(joinpath(datadir, "points.$ft"))
-        GeoTables.save(joinpath(writedir, "tpoints.geojson"), table)
-        newtable = GeoTables.load(joinpath(writedir, "tpoints.geojson"))
-        GeoTables.save(joinpath(writedir, "tpoints.shp"), table, force = true)
-        newtable = GeoTables.load(joinpath(writedir, "tpoints.shp"))
+        GeoTables.save(joinpath(savedir, "tpoints.geojson"), table)
+        newtable = GeoTables.load(joinpath(savedir, "tpoints.geojson"))
+        GeoTables.save(joinpath(savedir, "tpoints.shp"), table, force = true)
+        newtable = GeoTables.load(joinpath(savedir, "tpoints.shp"))
       end
     end
 
     @testset "lines" begin
       table = GeoTables.load(joinpath(datadir, "lines.geojson"), numbertype = Float64)
-      GeoTables.save(joinpath(writedir, "tlines.geojson"), table)
-      newtable = GeoTables.load(joinpath(writedir, "tlines.geojson"))
-      GeoTables.save(joinpath(writedir, "tlines.shp"), table, force = true)
-      newtable = GeoTables.load(joinpath(writedir, "tlines.shp"))
+      GeoTables.save(joinpath(savedir, "tlines.geojson"), table)
+      newtable = GeoTables.load(joinpath(savedir, "tlines.geojson"))
+      GeoTables.save(joinpath(savedir, "tlines.shp"), table, force = true)
+      newtable = GeoTables.load(joinpath(savedir, "tlines.shp"))
 
       for ft in ["gpkg", "shp"]
         table = GeoTables.load(joinpath(datadir, "lines.$ft"))
-        GeoTables.save(joinpath(writedir, "tlines.geojson"), table)
-        newtable = GeoTables.load(joinpath(writedir, "tlines.geojson"))
-        GeoTables.save(joinpath(writedir, "tlines.shp"), table, force = true)
-        newtable = GeoTables.load(joinpath(writedir, "tlines.shp"))
+        GeoTables.save(joinpath(savedir, "tlines.geojson"), table)
+        newtable = GeoTables.load(joinpath(savedir, "tlines.geojson"))
+        GeoTables.save(joinpath(savedir, "tlines.shp"), table, force = true)
+        newtable = GeoTables.load(joinpath(savedir, "tlines.shp"))
       end
     end
 
     @testset "polygons" begin
       table = GeoTables.load(joinpath(datadir, "polygons.geojson"), numbertype = Float64)
-      GeoTables.save(joinpath(writedir, "tpolygons.geojson"), table)
-      newtable = GeoTables.load(joinpath(writedir, "tpolygons.geojson"))
-      GeoTables.save(joinpath(writedir, "tpolygons.shp"), table, force = true)
-      newtable = GeoTables.load(joinpath(writedir, "tpolygons.shp"))
+      GeoTables.save(joinpath(savedir, "tpolygons.geojson"), table)
+      newtable = GeoTables.load(joinpath(savedir, "tpolygons.geojson"))
+      GeoTables.save(joinpath(savedir, "tpolygons.shp"), table, force = true)
+      newtable = GeoTables.load(joinpath(savedir, "tpolygons.shp"))
 
       for ft in ["gpkg", "shp"]
         table = GeoTables.load(joinpath(datadir, "polygons.$ft"))
-        GeoTables.save(joinpath(writedir, "tpolygons.geojson"), table)
-        newtable = GeoTables.load(joinpath(writedir, "tpolygons.geojson"))
-        GeoTables.save(joinpath(writedir, "tpolygons.shp"), table, force = true)
-        newtable = GeoTables.load(joinpath(writedir, "tpolygons.shp"))
+        GeoTables.save(joinpath(savedir, "tpolygons.geojson"), table)
+        newtable = GeoTables.load(joinpath(savedir, "tpolygons.geojson"))
+        GeoTables.save(joinpath(savedir, "tpolygons.shp"), table, force = true)
+        newtable = GeoTables.load(joinpath(savedir, "tpolygons.shp"))
       end
     end
 
     @testset "multipolygons" begin
       for file in ["path", "zone", "ne_110m_land"]
         table = GeoTables.load(joinpath(datadir,"$file.shp"))
-        GeoTables.save(joinpath(writedir, "t$file.geojson"), table)
-        newtable = GeoTables.load(joinpath(writedir, "t$file.geojson"))
-        GeoTables.save(joinpath(writedir, "t$file.shp"), table, force = true)
-        newtable = GeoTables.load(joinpath(writedir, "t$file.shp"))
+        GeoTables.save(joinpath(savedir, "t$file.geojson"), table)
+        newtable = GeoTables.load(joinpath(savedir, "t$file.geojson"))
+        GeoTables.save(joinpath(savedir, "t$file.shp"), table, force = true)
+        newtable = GeoTables.load(joinpath(savedir, "t$file.shp"))
       end
     end
   end
@@ -279,4 +279,4 @@ writedir = mktempdir()
   end
 end
 
-rm(writedir, recursive = true)
+rm(savedir, recursive = true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -278,5 +278,3 @@ savedir = mktempdir()
     @test nitems(table) == 36
   end
 end
-
-rm(savedir, recursive = true)


### PR DESCRIPTION
This PR should be accepted after JuliaGeo/Shapefile.jl#90 is merged. It adds the following features:

- Conversion from and to `Shapefile.jl`, `GeoJSON,jl` and `ArchGDAL.jl` is working fine. So tests include `Shapefile.jl` conversions for `Chain` and `PolyArea`.
- Writing `GeoTables` with `Chain` and `PolyArea` geometries to `Shapefile.jl` is now posssible. So tests for `lines.*` and `polygons.*` to `.shp` are included.
- I have refactored the tests to reduce the number of lines.
- I also think would be better to write a the data to a temporal directory, so we do not need to remove those files.