### PR TITLE
fix tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -259,8 +259,8 @@ savedir = mktempdir()
 
       for ft in ["gpkg", "shp"]
         table = GeoTables.load(joinpath(datadir, "lines.$ft"))
-        # GeoTables.save(joinpath(savedir, "tlines.geojson"), table)
-        # newtable = GeoTables.load(joinpath(savedir, "tlines.geojson"))
+        GeoTables.save(joinpath(savedir, "tlines.geojson"), table)
+        newtable = GeoTables.load(joinpath(savedir, "tlines.geojson"))
         GeoTables.save(joinpath(savedir, "tlines.shp"), table, force=true)
         newtable = GeoTables.load(joinpath(savedir, "tlines.shp"))
       end
@@ -275,18 +275,19 @@ savedir = mktempdir()
 
       for ft in ["gpkg", "shp"]
         table = GeoTables.load(joinpath(datadir, "polygons.$ft"))
-        # GeoTables.save(joinpath(savedir, "tpolygons.geojson"), table)
-        # newtable = GeoTables.load(joinpath(savedir, "tpolygons.geojson"))
+        GeoTables.save(joinpath(savedir, "tpolygons.geojson"), table)
+        newtable = GeoTables.load(joinpath(savedir, "tpolygons.geojson"))
         GeoTables.save(joinpath(savedir, "tpolygons.shp"), table, force=true)
         newtable = GeoTables.load(joinpath(savedir, "tpolygons.shp"))
       end
     end
 
     @testset "multipolygons" begin
+      # the file `ne_110m_land` needs Float64 precision
       for file in ["path", "zone", "ne_110m_land"]
         table = GeoTables.load(joinpath(datadir, "$file.shp"))
-        # GeoTables.save(joinpath(savedir, "t$file.geojson"), table)
-        # newtable = GeoTables.load(joinpath(savedir, "t$file.geojson"))
+        GeoTables.save(joinpath(savedir, "t$file.geojson"), table)
+        newtable = GeoTables.load(joinpath(savedir, "t$file.geojson"), numbertype = Float64)
         GeoTables.save(joinpath(savedir, "t$file.shp"), table, force=true)
         newtable = GeoTables.load(joinpath(savedir, "t$file.shp"))
       end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -284,10 +284,17 @@ savedir = mktempdir()
 
     @testset "multipolygons" begin
       # the file `ne_110m_land` needs Float64 precision
-      for file in ["path", "zone", "ne_110m_land"]
+      file = "ne_110m_land"
+      table = GeoTables.load(joinpath(datadir, "$file.shp"))
+      GeoTables.save(joinpath(savedir, "t$file.geojson"), table)
+      newtable = GeoTables.load(joinpath(savedir, "t$file.geojson"), numbertype = Float64)
+      GeoTables.save(joinpath(savedir, "t$file.shp"), table, force=true)
+      newtable = GeoTables.load(joinpath(savedir, "t$file.shp"))
+
+      for file in ["path", "zone"]
         table = GeoTables.load(joinpath(datadir, "$file.shp"))
         GeoTables.save(joinpath(savedir, "t$file.geojson"), table)
-        newtable = GeoTables.load(joinpath(savedir, "t$file.geojson"), numbertype = Float64)
+        newtable = GeoTables.load(joinpath(savedir, "t$file.geojson"))
         GeoTables.save(joinpath(savedir, "t$file.shp"), table, force=true)
         newtable = GeoTables.load(joinpath(savedir, "t$file.shp"))
       end


### PR DESCRIPTION
PR to be merged after JuliaGeo/GeoJSON.jl#68 is merged. It fixes JuliaEarth/GeoTables.jl#24, to summarize the errors we obtained were because:

1. There was a bug in `GeoJSON.jl` that was saving `MultiLineStrings` as `Polygons`.
2. The file `ne_110m_land.shp` needs Float64 precision when reading with `GeoJSON` as suggested by @eliascarv .
