### PR TITLE
FIX: show missing value columns

### DIFF
--- a/src/abstractgeotable.jl
+++ b/src/abstractgeotable.jl
@@ -380,10 +380,10 @@ function _common_kwargs(geotable)
       x = Tables.getcolumn(cols, name)
       T = eltype(x)
       if T <: Quantity
-        t = string(nameof(Continuous))
+        t = "Continuous"
         u = "[$(unit(T))]"
       else
-        t = string(nameof(nonmissingtype(elscitype(x))))
+        t = _coltype(x)
         u = "[NoUnits]"
       end
     end
@@ -394,3 +394,7 @@ function _common_kwargs(geotable)
 
   (title=summary(geotable), header=(colnames, types, units), alignment=:c, vcrop_mode=:bottom)
 end
+
+_coltype(x) = _coltype(x, elscitype(x))
+_coltype(x, ::Type) = string(nameof(nonmissingtype(elscitype(x))))
+_coltype(x, ::Type{Missing}) = "Missing"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -344,6 +344,26 @@ dummymeta(domain, table) = GeoTable(domain, Dict(paramdim(domain) => table))
       │     8     │    8.46    │  missing  │ (9.0, 9.0) │
       └───────────┴────────────┴───────────┴────────────┘"""
 
+      gtb = georef((; x=fill(missing, 9)), pset)
+      @test sprint(show, gtb) == "9×2 GeoTable over 9 PointSet{2,Float64}"
+      @test sprint(show, MIME("text/plain"), gtb) == """
+      9×2 GeoTable over 9 PointSet{2,Float64}
+      ┌───────────┬────────────┐
+      │     x     │  geometry  │
+      │  Missing  │   Point2   │
+      │ [NoUnits] │            │
+      ├───────────┼────────────┤
+      │  missing  │ (1.0, 1.0) │
+      │  missing  │ (2.0, 2.0) │
+      │  missing  │ (3.0, 3.0) │
+      │  missing  │ (4.0, 4.0) │
+      │  missing  │ (5.0, 5.0) │
+      │  missing  │ (6.0, 6.0) │
+      │  missing  │ (7.0, 7.0) │
+      │  missing  │ (8.0, 8.0) │
+      │  missing  │ (9.0, 9.0) │
+      └───────────┴────────────┘"""
+
       gtb = georef((; a, b, c), pset)
       @test sprint(show, MIME("text/html"), gtb) == """
       <table>


### PR DESCRIPTION
```julia
julia> georef((; x=[missing]), [(0, 0)])
1×2 GeoTable over 1 PointSet{2,Float64}
┌───────────┬────────────┐
│     x     │  geometry  │
│  Missing  │   Point2   │
│ [NoUnits] │            │
├───────────┼────────────┤
│  missing  │ (0.0, 0.0) │
└───────────┴────────────┘
```

closes #58 