### PR TITLE
FIX: `hcat(gtb1, gtb2)` does not maintain column types

### DIFF
--- a/src/abstractgeotable.jl
+++ b/src/abstractgeotable.jl
@@ -305,9 +305,10 @@ function _hcat(geotable1, geotable2)
       throw(ArgumentError("all geotables must have different variables"))
     end
 
-    columns1 = [Tables.getcolumn(cols1, name) for name in names1]
-    columns2 = [Tables.getcolumn(cols2, name) for name in names2]
-    columns = [columns1; columns2]
+    columns = Any[Tables.getcolumn(cols1, name) for name in names1]
+    for name in names2
+      push!(columns, Tables.getcolumn(cols2, name))
+    end
 
     (; zip(names, columns)...)
   elseif !isnothing(tab1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -125,6 +125,12 @@ dummymeta(domain, table) = GeoTable(domain, Dict(paramdim(domain) => table))
       @test hdata.e == data₃.e
       @test hdata.f == data₃.f
       @test hdata.geometry == dom
+      # maintain column types
+      data₁ = dummy(dom, (; a=rand(10)))
+      data₂ = dummy(dom, (; b=rand(1:10, 10)))
+      hdata = hcat(data₁, data₂)
+      @test eltype(hdata.a) === Float64
+      @test eltype(hdata.b) === Int
       # throws
       data₁ = dummy(dom, (a=rand(10), b=rand(10)))
       data₂ = dummy(dom, (a=rand(10), c=rand(10)))


### PR DESCRIPTION
This happens when tables have only 1 column:
```julia
julia> pset = PointSet(rand(Point2, 10));

julia> gtb1 = georef((; a=rand(10)), pset)
10×2 GeoTable over 10 PointSet{2,Float64}
┌────────────┬───────────────────────┐
│     a      │       geometry        │
│ Continuous │        Point2         │
│ [NoUnits]  │                       │
├────────────┼───────────────────────┤
│  0.202371  │ (0.593518, 0.938217)  │
│  0.502582  │ (0.288532, 0.152239)  │
│     ⋮      │           ⋮           │
└────────────┴───────────────────────┘
                        8 rows omitted

julia> gtb2 = georef((; b=rand(1:10, 10)), pset)
10×2 GeoTable over 10 PointSet{2,Float64}
┌───────────┬───────────────────────┐
│     b     │       geometry        │
│   Count   │        Point2         │
│ [NoUnits] │                       │
├───────────┼───────────────────────┤
│     4     │ (0.593518, 0.938217)  │
│     1     │ (0.288532, 0.152239)  │
│     ⋮     │           ⋮           │
└───────────┴───────────────────────┘
                       8 rows omitted

julia> hcat(gtb1, gtb2)
10×3 GeoTable over 10 PointSet{2,Float64}
┌────────────┬────────────┬───────────────────────┐
│     a      │     b      │       geometry        │
│ Continuous │ Continuous │        Point2         │
│ [NoUnits]  │ [NoUnits]  │                       │
├────────────┼────────────┼───────────────────────┤
│  0.202371  │    4.0     │ (0.593518, 0.938217)  │
│  0.502582  │    1.0     │ (0.288532, 0.152239)  │
│     ⋮      │     ⋮      │           ⋮           │
└────────────┴────────────┴───────────────────────┘
                                     8 rows omitted
```