### PR TITLE
FIX: show unit when column has missing values

### DIFF
--- a/src/GeoTables.jl
+++ b/src/GeoTables.jl
@@ -11,6 +11,8 @@ using PrettyTables
 using ScientificTypes
 using Unitful
 
+using Unitful: AbstractQuantity
+
 import DataAPI: nrow, ncol
 import Meshes: partitioninds
 import Meshes: sampleinds

--- a/src/abstractgeotable.jl
+++ b/src/abstractgeotable.jl
@@ -136,7 +136,7 @@ function _common_kwargs(geotable)
     else
       cols = Tables.columns(tab)
       x = Tables.getcolumn(cols, name)
-      T = eltype(x)
+      T = nonmissingtype(eltype(x))
       if T <: Quantity
         t = "Continuous"
         u = "[$(unit(T))]"

--- a/src/abstractgeotable.jl
+++ b/src/abstractgeotable.jl
@@ -136,12 +136,15 @@ function _common_kwargs(geotable)
     else
       cols = Tables.columns(tab)
       x = Tables.getcolumn(cols, name)
-      T = nonmissingtype(eltype(x))
-      if T <: Quantity
+      T = eltype(x)
+      if T <: Missing
+        t = "Missing"
+        u = "[NoUnits]"
+      elseif nonmissingtype(T) <: AbstractQuantity
         t = "Continuous"
         u = "[$(unit(T))]"
       else
-        t = _coltype(x)
+        t = string(nameof(nonmissingtype(elscitype(x))))
         u = "[NoUnits]"
       end
     end
@@ -152,7 +155,3 @@ function _common_kwargs(geotable)
 
   (title=summary(geotable), header=(colnames, types, units), alignment=:c, vcrop_mode=:bottom)
 end
-
-_coltype(x) = _coltype(x, elscitype(x))
-_coltype(x, ::Type) = string(nameof(nonmissingtype(elscitype(x))))
-_coltype(x, ::Type{Missing}) = "Missing"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -444,6 +444,26 @@ dummymeta(domain, table) = GeoTable(domain, Dict(paramdim(domain) => table))
       │     8     │    8.46    │  missing  │ (9.0, 9.0) │
       └───────────┴────────────┴───────────┴────────────┘"""
 
+      gtb = georef((a=[missing; a[2:9]] * u"m/s", b=[b[1:4]; missing; b[6:9]] * u"km/hr", c=[c[1:8]; missing]), pset)
+      @test sprint(show, gtb) == "9×4 GeoTable over 9 PointSet{2,Float64}"
+      @test sprint(show, MIME("text/plain"), gtb) == """
+      9×4 GeoTable over 9 PointSet{2,Float64}
+      ┌────────────┬───────────────┬───────────┬────────────┐
+      │     a      │       b       │     c     │  geometry  │
+      │ Continuous │  Continuous   │  Textual  │   Point2   │
+      │  [m s^-1]  │  [km hr^-1]   │ [NoUnits] │            │
+      ├────────────┼───────────────┼───────────┼────────────┤
+      │  missing   │ 2.34 km hr^-1 │   txt1    │ (1.0, 1.0) │
+      │  6 m s^-1  │ 7.5 km hr^-1  │   txt2    │ (2.0, 2.0) │
+      │  6 m s^-1  │ 0.06 km hr^-1 │   txt3    │ (3.0, 3.0) │
+      │  3 m s^-1  │ 1.29 km hr^-1 │   txt4    │ (4.0, 4.0) │
+      │  9 m s^-1  │    missing    │   txt5    │ (5.0, 5.0) │
+      │  5 m s^-1  │ 8.05 km hr^-1 │   txt6    │ (6.0, 6.0) │
+      │  2 m s^-1  │ 0.11 km hr^-1 │   txt7    │ (7.0, 7.0) │
+      │  2 m s^-1  │ 0.64 km hr^-1 │   txt8    │ (8.0, 8.0) │
+      │  8 m s^-1  │ 8.46 km hr^-1 │  missing  │ (9.0, 9.0) │
+      └────────────┴───────────────┴───────────┴────────────┘"""
+
       gtb = georef((; x=fill(missing, 9)), pset)
       @test sprint(show, gtb) == "9×2 GeoTable over 9 PointSet{2,Float64}"
       @test sprint(show, MIME("text/plain"), gtb) == """


### PR DESCRIPTION
Bug:
```julia
julia> gtb
9×4 GeoTable over 9 PointSet{2,Float64}
┌───────────┬───────────────┬───────────┬────────────┐
│     a     │       b       │     c     │  geometry  │
│  Unknown  │    Unknown    │  Textual  │   Point2   │
│ [NoUnits] │   [NoUnits]   │ [NoUnits] │            │
├───────────┼───────────────┼───────────┼────────────┤
│  missing  │ 2.34 km hr^-1 │   txt1    │ (1.0, 1.0) │
│ 6 m s^-1  │ 7.5 km hr^-1  │   txt2    │ (2.0, 2.0) │
│ 6 m s^-1  │ 0.06 km hr^-1 │   txt3    │ (3.0, 3.0) │
│ 3 m s^-1  │ 1.29 km hr^-1 │   txt4    │ (4.0, 4.0) │
│ 9 m s^-1  │    missing    │   txt5    │ (5.0, 5.0) │
│ 5 m s^-1  │ 8.05 km hr^-1 │   txt6    │ (6.0, 6.0) │
│ 2 m s^-1  │ 0.11 km hr^-1 │   txt7    │ (7.0, 7.0) │
│ 2 m s^-1  │ 0.64 km hr^-1 │   txt8    │ (8.0, 8.0) │
│ 8 m s^-1  │ 8.46 km hr^-1 │  missing  │ (9.0, 9.0) │
└───────────┴───────────────┴───────────┴────────────┘
```