### PR TITLE
Make `Unknown` variables viewable if they are color columns

### DIFF
--- a/ext/GeoTablesMakieExt/viewer.jl
+++ b/ext/GeoTablesMakieExt/viewer.jl
@@ -153,6 +153,12 @@ skipinvalid(vals) = (v for v in vals if !isinvalid(v))
 
 isviewable(vals) = isviewable(elscitype(vals), vals)
 isviewable(::Type, vals) = false
+isviewable(::Type{Unknown}, vals) = iscolor(vals)
 isviewable(::Type{Continuous}, vals) = !all(isinvalid, vals)
 isviewable(::Type{Categorical}, vals) = true
 isviewable(::Type{Distributional}, vals) = true
+
+iscolor(vals) = iscolor(nonmissingtype(eltype(vals)))
+iscolor(::Type) = false
+iscolor(::Type{Union{}}) = false
+iscolor(::Type{<:Colorant}) = true


### PR DESCRIPTION
```julia
gtb1 = georef((; color=[Gray(x) for x in rand(10, 10)]))
gtb2 = georef((; color=[x > 0.5 ? Gray(x) : missing for x in rand(10, 10)]))
gtb3 = georef((; color=[missing for x in rand(10, 10)]))

# eltype(gtb.color) <: Colorant
# viewable
viewer(gtb1)

# eltype(gtb.color) <: Union{Missing,Colorant}
# viewable
viewer(gtb2)

# eltype(gtb.color) <: Missing
# no viewable
viewer(gtb3) 
```