### PR TITLE
Add notes for tables at different ranks in GeoTable show method

### DIFF
--- a/src/abstractgeotable.jl
+++ b/src/abstractgeotable.jl
@@ -175,11 +175,20 @@ function _common_kwargs(geotable)
   labels₂ = getindex.(labels, 2)
   labels₃ = getindex.(labels, 3)
 
+  notes = ""
+  for rank in 0:(paramdim(dom) - 1)
+    rtab = values(geotable, rank)
+    if !isnothing(rtab)
+      notes *= "Additional variables at rank $rank. "
+    end
+  end
+
   (
     title=summary(geotable),
     column_labels=[labels₁, labels₂, labels₃],
     maximum_number_of_rows=10,
     new_line_at_end=false,
+    source_notes=notes,
     alignment=:c
   )
 end

--- a/test/shows.jl
+++ b/test/shows.jl
@@ -162,6 +162,23 @@ if !Sys.isapple()
     │ (x: 9.0 m, y: 9.0 m) │
     └──────────────────────┘"""
 
+    # vertex table
+    gtb = GeoTable(CartesianGrid(2, 2), vtable=(; a=rand(3*3), b=rand(3*3)))
+    @test sprint(show, gtb) == "4×1 GeoTable over 2×2 CartesianGrid"
+    @test sprint(show, MIME("text/plain"), gtb) == """
+                  4×1 GeoTable over 2×2 CartesianGrid
+    ┌─────────────────────────────────────────────────────────────┐
+    │                          geometry                           │
+    │                         Quadrangle                          │
+    │                    🖈 Cartesian{NoDatum}                     │
+    ├─────────────────────────────────────────────────────────────┤
+    │ Quadrangle((x: 0.0 m, y: 0.0 m), ..., (x: 0.0 m, y: 1.0 m)) │
+    │ Quadrangle((x: 1.0 m, y: 0.0 m), ..., (x: 1.0 m, y: 1.0 m)) │
+    │ Quadrangle((x: 0.0 m, y: 1.0 m), ..., (x: 0.0 m, y: 2.0 m)) │
+    │ Quadrangle((x: 1.0 m, y: 1.0 m), ..., (x: 1.0 m, y: 2.0 m)) │
+    └─────────────────────────────────────────────────────────────┘
+    Additional variables at rank 0."""
+
     # https://github.com/JuliaLang/StyledStrings.jl/issues/122
     # gtb = georef((; a, b, c), pset)
     # @test sprint(show, MIME("text/html"), gtb) == """


### PR DESCRIPTION
To give users a chance to learn about vertex tables and other rank-tables when available.